### PR TITLE
Follow-up to #1640

### DIFF
--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 RabbitMQ.Client.BasicProperties.BasicProperties(RabbitMQ.Client.IReadOnlyBasicProperties! input) -> void
+RabbitMQ.Client.TimerBasedCredentialRefresher.Dispose() -> void

--- a/projects/RabbitMQ.Client/client/api/BasicCredentialsProvider.cs
+++ b/projects/RabbitMQ.Client/client/api/BasicCredentialsProvider.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client
             get { return _password; }
         }
 
-        public Nullable<TimeSpan> ValidUntil
+        public TimeSpan? ValidUntil
         {
             get
             {

--- a/projects/RabbitMQ.Client/client/api/ICredentialsProvider.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsProvider.cs
@@ -29,6 +29,8 @@
 //  Copyright (c) 2007-2024 Broadcom. All Rights Reserved.
 //---------------------------------------------------------------------------
 
+using System;
+
 namespace RabbitMQ.Client
 {
     public interface ICredentialsProvider
@@ -41,7 +43,7 @@ namespace RabbitMQ.Client
         /// If credentials have an expiry time this property returns the interval.
         /// Otherwise, it returns null.
         /// </summary>
-        System.TimeSpan? ValidUntil { get; }
+        TimeSpan? ValidUntil { get; }
 
         /// <summary>
         /// Before the credentials are available, be it Username, Password or ValidUntil,

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -78,11 +78,6 @@ namespace RabbitMQ.Client
 
         public ICredentialsProvider Register(ICredentialsProvider provider, ICredentialsRefresher.NotifyCredentialRefreshedAsync callback)
         {
-            if (_credentialsProvider is not null)
-            {
-                throw new InvalidOperationException("Already registered a credentials provider.");
-            }
-
             // TODO should this be ArgumentException?
             if (provider.ValidUntil is null)
             {
@@ -94,6 +89,8 @@ namespace RabbitMQ.Client
             {
                 return provider;
             }
+
+            Reset();
 
             _credentialsProvider = provider;
             _registration = new TimerRegistration(callback);
@@ -129,21 +126,26 @@ namespace RabbitMQ.Client
 
             try
             {
-                if (_credentialsProvider is not null)
-                {
-                    TimerBasedCredentialRefresherEventSource.Log.Unregistered(_credentialsProvider.Name);
-                    _credentialsProvider = null;
-                }
-
-                if (_registration is not null)
-                {
-                    _registration.Dispose();
-                    _registration = null;
-                }
+                Reset();
             }
             finally
             {
                 _disposed = true;
+            }
+        }
+
+        private void Reset()
+        {
+            if (_credentialsProvider is not null)
+            {
+                TimerBasedCredentialRefresherEventSource.Log.Unregistered(_credentialsProvider.Name);
+                _credentialsProvider = null;
+            }
+
+            if (_registration is not null)
+            {
+                _registration.Dispose();
+                _registration = null;
             }
         }
 

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -260,6 +260,9 @@ namespace RabbitMQ.Client.Framing.Impl
                  * https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1623 
                  */
                 _innerConnection = maybeNewInnerConnection;
+
+                defunctConnection.Dispose();
+
                 return true;
             }
             catch (Exception e)

--- a/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
@@ -200,7 +200,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private async Task NotifyCredentialRefreshedAsync(bool succesfully)
         {
-            if (succesfully)
+            if (succesfully && IsOpen)
             {
                 using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionCloseTimeout);
                 await UpdateSecretAsync(_config.CredentialsProvider.Password, "Token refresh", cts.Token)

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -484,7 +484,6 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 _session0.Dispose();
                 _mainLoopCts.Dispose();
-                _config.CredentialsRefresher.Dispose();
             }
             catch (OperationInterruptedException)
             {

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -484,6 +484,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 _session0.Dispose();
                 _mainLoopCts.Dispose();
+                _config.CredentialsRefresher.Dispose();
             }
             catch (OperationInterruptedException)
             {


### PR DESCRIPTION
* Only allow one `ICredentialsProvider` registration per `TimerBasedCredentialRefresher`
* Use automatic reset of timer in `TimerBasedCredentialRefresher`
* Dispose of inner connection during automatic recovery